### PR TITLE
Remove AuthMethods directive

### DIFF
--- a/sftp.conf
+++ b/sftp.conf
@@ -5,7 +5,6 @@
     SFTPLog /var/log/proftpd/sftp.log
     SFTPHostKey /etc/proftpd/sftp/keys/ssh_host_rsa_key
     SFTPHostKey /etc/proftpd/sftp/keys/ssh_host_ecdsa_key
-    SFTPAuthMethods %{env:SFTP_AUTH_METHODS}
     SFTPAuthorizedUserKeys file:/etc/proftpd/sftp/authorized_keys/%u
     SFTPCompression delayed
     SFTPCiphers aes256-ctr aes192-ctr aes128-ctr


### PR DESCRIPTION
As we want to be able to accept any method (and using multiple methods described in the documentation seems to crash proftpd on startup), the best way is to simply remove this directive